### PR TITLE
Fix Fabric CA download link

### DIFF
--- a/scripts/setupNetwork.sh
+++ b/scripts/setupNetwork.sh
@@ -5,7 +5,7 @@ SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" # Wh
 function networkUp() {
 	networkDown
 	cd $SRC_DIR/..
-	curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.2.3 1.5.0
+	curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.2.3 1.5.1
 	cd fabric-samples
 	git checkout release-2.2
 	cd test-network


### PR DESCRIPTION
There is only darwin binary in Fabric CA v1.5.0.
This PR changes a link to v1.5.1 which has darwin, linux,
and windows binaries.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>